### PR TITLE
feat: Added data of product complete in events

### DIFF
--- a/src/events/application/services/EventService.ts
+++ b/src/events/application/services/EventService.ts
@@ -4,6 +4,7 @@ import {
   EventResponse,
   EventResponseOrNull,
 } from "../../../types";
+import { DomainEvent } from "../../domain/entities/domainEvent";
 import { EventRepository } from "../../infrastructure/repositories/eventRepositoryImpl";
 
 const eventRepository = new EventRepository();
@@ -24,7 +25,10 @@ export const saveEvent = async (
   date: string,
   name: string,
   productIds: string[]
-): EventResponse => {
+): Promise<{
+  event: DomainEvent;
+  products: { id: string; [key: string]: any }[];
+}> => {
   return await eventRepository.save(userId, name, date, productIds);
 };
 

--- a/src/events/domain/interfaces/IEventRepository.ts
+++ b/src/events/domain/interfaces/IEventRepository.ts
@@ -4,6 +4,7 @@ import {
   EventResponse,
   EventResponseOrNull,
 } from "../../../types";
+import { DomainEvent } from "../entities/domainEvent";
 
 export interface IEventRepository {
   findAll(userId: string): EventListResponse;
@@ -13,7 +14,10 @@ export interface IEventRepository {
     name: string,
     date: string,
     productIds: string[]
-  ): EventResponse;
+  ): Promise<{
+    event: DomainEvent;
+    products: { id: string; [key: string]: any }[];
+  }>;
   update(
     id: string,
     userId: string,

--- a/src/events/infrastructure/repositories/eventRepositoryImpl.ts
+++ b/src/events/infrastructure/repositories/eventRepositoryImpl.ts
@@ -41,19 +41,22 @@ export class EventRepository implements IEventRepository {
     date: string,
     name: string,
     productIds: string[]
-  ): EventResponse {
+  ): Promise<{
+    event: DomainEvent;
+    products: { id: string; [key: string]: any }[];
+  }> {
     const supabaseCall = async () => {
       return await supabase
         .from(TABLE_NAME_PRODUCTS)
-        .select("id")
+        .select("*")
         .in(COLUMNS.ID, productIds);
     };
     const validateProducts = await buildRepository<{ id: string }[]>({
       supabaseCall,
     });
 
-    console.log({ validateProducts });
-    console.log({ productIds });
+    console.log("validateProducts", validateProducts);
+
     if (
       validateProducts.length !== productIds.length ||
       validateProducts.length <= 0
@@ -63,7 +66,6 @@ export class EventRepository implements IEventRepository {
       );
     }
     const validProductIds = validateProducts.map((product) => product.id);
-    console.log({ validProductIds });
     const createEvent = async () => {
       return await supabase
         .from(TABLE_NAME)
@@ -90,7 +92,7 @@ export class EventRepository implements IEventRepository {
     await buildRepository<DomainEvent>({
       supabaseCall: insertShoppyListEntries,
     });
-    return eventData;
+    return { event: eventData, products: validateProducts };
   }
 
   async update(


### PR DESCRIPTION
🚀 Descripción
--
En este PR se añade la respuesta completa de productos segun su id.

✅ Cambios realizados
--
 Cambio 1: Se reajusto la estructura de la respuesta del endpoint save en eventos, para que pudiese obtener todo lo referente a cada id que se le asigna en el cuerpo o petición.
 Cambio 2: Se reajusto la estructura en como debería retornar el repository save.

📸 Capturas de pantalla
--
![data products](https://github.com/user-attachments/assets/be1295e7-87a3-4ef8-bf19-39d04a368ed5)
